### PR TITLE
Support key param for sortBy and sortByDescending

### DIFF
--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -54,8 +54,8 @@ import {Reverse} from "./reverse";
 import {Single} from "./single";
 import {SingleOrNull} from "./singleOrNull";
 import {Sorted} from "./sorted";
-import {SortedBy} from "./sortedBy";
-import {SortedByDescending} from "./sortedByDescending";
+import {SortedBy, SortedByOperator} from "./sortedBy";
+import {SortedByDescending, SortedByDescendingOperator} from "./sortedByDescending";
 import {SortedDescending} from "./sortedDescending";
 import {SortedWith} from "./sortedWith";
 import {Sum} from "./sum";
@@ -89,8 +89,8 @@ export default Sequence;
 export interface SequenceOperators<T> extends All, Any, AsIterable, Associate, AssociateBy<T>, Average, Chunk, Contains, Count, Distinct, DistinctBy, Drop,
     DropWhile, ElementAt, ElementAtOrElse, ElementAtOrNull, Filter, FilterIndexed, FilterNot, FilterNotNull, First, FirstOrNull, FlatMap, Flatten, Fold, FoldIndexed,
     ForEach, ForEachIndexed, GroupBy, IndexOf, IndexOfFirst, IndexOfLast, JoinToString, Last, LastOrNull, Map, MapIndexed, MapNotNull, Max, MaxBy, MaxWith, Merge, Min, MinBy,
-    Minus, MinWith, None, OnEach, Partition, Plus, Reduce, ReduceIndexed, Reverse, Single, SingleOrNull, Sorted, SortedBy, SortedByDescending, SortedDescending, SortedWith,
-    Sum, SumBy, Take, TakeWhile, ToArray, ToMap, ToSet, Unzip, WithIndex, Zip {
+    Minus, MinWith, None, OnEach, Partition, Plus, Reduce, ReduceIndexed, Reverse, Single, SingleOrNull, Sorted, SortedByOperator, SortedByDescendingOperator, SortedDescending,
+    SortedWith, Sum, SumBy, Take, TakeWhile, ToArray, ToMap, ToSet, Unzip, WithIndex, Zip {
 }
 
 class SequenceImpl<T> {

--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -174,3 +174,6 @@ export function range(start: number, endInclusive: number, step: number = 1): Se
         }
     });
 }
+
+export { default as Comparator } from "./Comparator";
+export { default as ComparatorFactory } from "./ComparatorFactory";

--- a/src/asSelector.ts
+++ b/src/asSelector.ts
@@ -1,0 +1,7 @@
+export function asSelector<T>(
+  keyOrSelector: keyof T | ((item: T) => any)
+) {
+  return typeof keyOrSelector === "function"
+    ? keyOrSelector
+    : (item: T) => item[keyOrSelector];
+}

--- a/src/createComparatorFactory.ts
+++ b/src/createComparatorFactory.ts
@@ -1,3 +1,4 @@
+import { asSelector } from "./asSelector";
 import ComparatorFactory from "./ComparatorFactory";
 import Comparator from "./Comparator";
 
@@ -53,12 +54,6 @@ function compareByDescending<T>(keyOrSelector: any): Comparator<T> {
     return compare<T>(
         (a: T, b: T) => naturalCompare(selector(b), selector(a))
     );
-}
-
-function asSelector<T>(keyOrSelector: (item: T) => any | string): (item: T) => any {
-    return typeof keyOrSelector === "function"
-        ? keyOrSelector
-        : (item: T) => (item as any)[keyOrSelector as string];
 }
 
 function naturalCompare<T>(a: T, b: T): number {

--- a/src/sortedBy.ts
+++ b/src/sortedBy.ts
@@ -1,6 +1,7 @@
+import { asSelector } from "./asSelector";
 import Sequence from "./Sequence";
 
-export class SortedBy {
+export interface SortedByOperator {
 
     /**
      * Returns a new sequence with all elements sorted ascending by the value specified
@@ -9,7 +10,21 @@ export class SortedBy {
      * @param {(value: T) => R} selector
      * @returns {Sequence<T>}
      */
-    sortedBy<T, R>(this: Sequence<T>, selector: (value: T) => R): Sequence<T> {
+    sortedBy<T, R>(this: Sequence<T>, selector: (value: T) => R): Sequence<T>;
+
+    /**
+     * Returns a new sequence with all elements sorted in ascending order of values for the given `key`.
+     *
+     * @param {keyof T} key
+     * @returns {Sequence<T>}
+     */
+    sortedBy<T>(this: Sequence<T>, key: keyof T): Sequence<T>;
+}
+
+export class SortedBy implements SortedByOperator {
+
+    sortedBy<T>(this:Sequence<T> , keyOrSelector: keyof T | ((value:T) => any)): Sequence<T> {
+        const selector = asSelector(keyOrSelector);
         return this.sorted(it => it.compareBy(selector));
     }
 

--- a/src/sortedByDescending.ts
+++ b/src/sortedByDescending.ts
@@ -1,7 +1,7 @@
+import { asSelector } from "./asSelector";
 import Sequence from "./Sequence";
 
-export class SortedByDescending {
-
+export interface SortedByDescendingOperator {
     /**
      * Returns a new sequence with all elements sorted descending by the value specified
      * by the given `selector` function.
@@ -9,7 +9,21 @@ export class SortedByDescending {
      * @param {(value: T) => R} selector
      * @returns {Sequence<T>}
      */
-    sortedByDescending<T, R>(this: Sequence<T>, selector: (value: T) => R): Sequence<T> {
+     sortedByDescending<T, R>(this: Sequence<T>, selector: (value: T) => R): Sequence<T>;
+
+     /**
+      * Returns a new sequence with all elements sorted in descending order of values for the given `key`.
+      *
+      * @param {keyof T} key
+      * @returns {Sequence<T>}
+      */
+    sortedByDescending<T>(this: Sequence<T>, key: keyof T): Sequence<T>;
+}
+
+export class SortedByDescending implements SortedByDescendingOperator {
+
+    sortedByDescending<T>(this: Sequence<T>, keyOrSelector: keyof T | ((value: T) => any)): Sequence<T> {
+        const selector = asSelector(keyOrSelector);
         return this.sorted(it => it.compareByDescending(selector));
     }
 

--- a/test/sortedBy.test.ts
+++ b/test/sortedBy.test.ts
@@ -1,7 +1,7 @@
 import {sequenceOf} from "../src/Sequence";
 
 describe("sortedBy", () => {
-    it("should sort by the given key ascending", () => {
+    it("should sort in ascending order using a selector", () => {
         const a4 = {a: 4};
         const a1 = {a: 1};
         const a3 = {a: 3};
@@ -9,6 +9,22 @@ describe("sortedBy", () => {
 
         const array = sequenceOf(a4, a1, a3, a23)
             .sortedBy(it => it.a)
+            .toArray();
+
+        expect(array.length).toBe(4);
+        expect(array[0]).toBe(a1);
+        expect(array[1]).toBe(a3);
+        expect(array[2]).toBe(a4);
+        expect(array[3]).toBe(a23);
+    });
+    it("should sort in ascending order using a key", () => {
+        const a4 = {a: 4};
+        const a1 = {a: 1};
+        const a3 = {a: 3};
+        const a23 = {a: 23};
+
+        const array = sequenceOf(a4, a1, a3, a23)
+            .sortedBy("a")
             .toArray();
 
         expect(array.length).toBe(4);

--- a/test/sortedByDescending.test.ts
+++ b/test/sortedByDescending.test.ts
@@ -1,7 +1,7 @@
 import {sequenceOf} from "../src/Sequence";
 
-describe("sortedBy", () => {
-    it("should sort by the given key descending", () => {
+describe("sortedByDescending", () => {
+    it("should sort in descending order using a selector", () => {
         const a4 = {a: 4};
         const a1 = {a: 1};
         const a3 = {a: 3};
@@ -9,6 +9,22 @@ describe("sortedBy", () => {
 
         const array = sequenceOf(a4, a1, a3, a23)
             .sortedByDescending(it => it.a)
+            .toArray();
+
+        expect(array.length).toBe(4);
+        expect(array[0]).toBe(a23);
+        expect(array[1]).toBe(a4);
+        expect(array[2]).toBe(a3);
+        expect(array[3]).toBe(a1);
+    });
+    it("should sort in descending order using a key", () => {
+        const a4 = {a: 4};
+        const a1 = {a: 1};
+        const a3 = {a: 3};
+        const a23 = {a: 23};
+
+        const array = sequenceOf(a4, a1, a3, a23)
+            .sortedByDescending("a")
             .toArray();
 
         expect(array.length).toBe(4);


### PR DESCRIPTION
Currently, it is possible to sort using the key of an item, but only through the `Comparator` and `ComparatorFactory` interfaces, for example:
https://github.com/winterbe/sequency/blob/7be941df1dce7c5ad50df60c1ddec72b46a54b54/test/sorted.test.ts#L67
https://github.com/winterbe/sequency/blob/7be941df1dce7c5ad50df60c1ddec72b46a54b54/test/sorted.test.ts#L89
https://github.com/winterbe/sequency/blob/7be941df1dce7c5ad50df60c1ddec72b46a54b54/test/sorted.test.ts#L108
https://github.com/winterbe/sequency/blob/7be941df1dce7c5ad50df60c1ddec72b46a54b54/test/sorted.test.ts#L135

The goal of this PR is to enable sorting by key directly on the ```Sequence``` type, like:
```ts
        sequenceOf(a4, a1, a3, a23)
            .sortedBy("a")
```
```ts
        sequenceOf(a4, a1, a3, a23)
            .sortedByDescending("a")
```

Also, this PR exports the `Comparator` and `ComparatorFactory` types, so that they are added to the docs (which suppresses a couple warnings when generating them)