### PR TITLE
Monadic extension for flatMap

### DIFF
--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -21,6 +21,7 @@ import {FilterNotNull} from "./filterNotNull";
 import {First} from "./first";
 import {FirstOrNull} from "./firstOrNull";
 import {FlatMap} from "./flatMap";
+import {FlatMapM} from "./flatMapM";
 import {Flatten} from "./flatten";
 import {Fold} from "./fold";
 import {FoldIndexed} from "./foldIndexed";
@@ -87,7 +88,7 @@ export default Sequence;
  * @hidden
  */
 export interface SequenceOperators<T> extends All, Any, AsIterable, Associate, AssociateBy<T>, Average, Chunk, Contains, Count, Distinct, DistinctBy, Drop,
-    DropWhile, ElementAt, ElementAtOrElse, ElementAtOrNull, Filter, FilterIndexed, FilterNot, FilterNotNull, First, FirstOrNull, FlatMap, Flatten, Fold, FoldIndexed,
+    DropWhile, ElementAt, ElementAtOrElse, ElementAtOrNull, Filter, FilterIndexed, FilterNot, FilterNotNull, First, FirstOrNull, FlatMap, FlatMapM, Flatten, Fold, FoldIndexed,
     ForEach, ForEachIndexed, GroupBy, IndexOf, IndexOfFirst, IndexOfLast, JoinToString, Last, LastOrNull, Map, MapIndexed, MapNotNull, Max, MaxBy, MaxWith, Merge, Min, MinBy,
     Minus, MinWith, None, OnEach, Partition, Plus, Reduce, ReduceIndexed, Reverse, Single, SingleOrNull, Sorted, SortedBy, SortedByDescending, SortedDescending, SortedWith,
     Sum, SumBy, Take, TakeWhile, ToArray, ToMap, ToSet, Unzip, WithIndex, Zip {
@@ -99,7 +100,7 @@ class SequenceImpl<T> {
 }
 
 applyMixins(SequenceImpl, [All, Any, AsIterable, Associate, AssociateBy, Average, Chunk, Contains, Count, Distinct, DistinctBy, Drop,
-    DropWhile, ElementAt, ElementAtOrElse, ElementAtOrNull, Filter, FilterIndexed, FilterNot, FilterNotNull, First, FirstOrNull, FlatMap, Flatten, Fold, FoldIndexed,
+    DropWhile, ElementAt, ElementAtOrElse, ElementAtOrNull, Filter, FilterIndexed, FilterNot, FilterNotNull, First, FirstOrNull, FlatMap, FlatMapM, Flatten, Fold, FoldIndexed,
     ForEach, ForEachIndexed, GroupBy, IndexOf, IndexOfFirst, IndexOfLast, JoinToString, Last, LastOrNull, Map, MapIndexed, MapNotNull, Max, MaxBy, MaxWith, Merge, Min, MinBy,
     Minus, MinWith, None, OnEach, Partition, Plus, Reduce, ReduceIndexed, Reverse, Single, SingleOrNull, Sorted, SortedBy, SortedByDescending, SortedDescending, SortedWith,
     Sum, SumBy, Take, TakeWhile, ToArray, ToMap, ToSet, Unzip, WithIndex, Zip]);

--- a/src/flatMapM.ts
+++ b/src/flatMapM.ts
@@ -1,0 +1,23 @@
+import Sequence, { asSequence } from "./Sequence";
+
+export class FlatMapM {
+    /**
+     * Transforms each element into an iterable of items and returns a flat single sequence of all those items. The M stands for Monadic
+     *
+     * @param {(value: S) => Iterable<T>} transform
+     * @returns {Sequence<T>}
+     * @example
+     *  asSequence(document.querySelectorAll("form"))
+     *      .flatMapM(form => form.querySelectorAll("input"))
+     *  // same as
+     *  asSequence(document.querySelectorAll("form"))
+     *      .map(form => form.querySelectorAll("input"))
+     *      .flatMap(asSequence)
+     * 
+     *
+     */
+    flatMapM<S, T>(this: Sequence<S>, transform: (value: S) => Iterable<T>): Sequence<T> {
+        return this.flatMap(value => asSequence(transform(value)));
+    }
+
+}

--- a/test/flatMapM.test.ts
+++ b/test/flatMapM.test.ts
@@ -1,0 +1,32 @@
+import { asSequence, sequenceOf } from "../src/Sequence";
+
+describe("flatMapM", () => {
+    it("should flatten element arrays", () => {
+        const array = sequenceOf([1, 2], [3, 4], [5, 6])
+            .flatMapM(it => it)
+            .toArray();
+
+        expect(array.length).toBe(6);
+        expect(array[0]).toBe(1);
+        expect(array[1]).toBe(2);
+        expect(array[2]).toBe(3);
+        expect(array[3]).toBe(4);
+        expect(array[4]).toBe(5);
+        expect(array[5]).toBe(6);
+    });
+
+    it("should flatten iterable iterators", () => {
+        const array = asSequence([
+            new Map([["a", 1], ["c", 3]]),
+            new Map([["b", 2], ["d", 4]]),
+        ])
+            .flatMapM(map => map.values())
+            .toArray();
+
+        expect(array.length).toBe(4);
+        expect(array[0]).toBe(1);
+        expect(array[1]).toBe(3);
+        expect(array[2]).toBe(2);
+        expect(array[3]).toBe(4);
+    });
+});


### PR DESCRIPTION
`flatMap` is really handy, but the fact it **has** to return a `Sequence` make it a bit cumbersome to use. In this PR I introduce `flatMapM` which is a more "monadic" version of `flatMap` that allows the user to return any `Iterable` instead.

`seq.flatMapM(f)` is strictly equivalent to `seq.map(f).flatMap(asSequence)`.