### PR TITLE
Add `isEmpty` and `isNotEmpty` utility methods

### DIFF
--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -30,6 +30,8 @@ import {GroupBy} from "./groupBy";
 import {IndexOf} from "./indexOf";
 import {IndexOfFirst} from "./indexOfFirst";
 import {IndexOfLast} from "./indexOfLast";
+import {IsEmpty} from "./isEmpty";
+import {IsNotEmpty} from "./isNotEmpty";
 import {JoinToString} from "./joinToString";
 import {Last} from "./last";
 import {LastOrNull} from "./lastOrNull";
@@ -88,7 +90,7 @@ export default Sequence;
  */
 export interface SequenceOperators<T> extends All, Any, AsIterable, Associate, AssociateBy<T>, Average, Chunk, Contains, Count, Distinct, DistinctBy, Drop,
     DropWhile, ElementAt, ElementAtOrElse, ElementAtOrNull, Filter, FilterIndexed, FilterNot, FilterNotNull, First, FirstOrNull, FlatMap, Flatten, Fold, FoldIndexed,
-    ForEach, ForEachIndexed, GroupBy, IndexOf, IndexOfFirst, IndexOfLast, JoinToString, Last, LastOrNull, Map, MapIndexed, MapNotNull, Max, MaxBy, MaxWith, Merge, Min, MinBy,
+    ForEach, ForEachIndexed, GroupBy, IndexOf, IndexOfFirst, IndexOfLast, IsEmpty, IsNotEmpty, JoinToString, Last, LastOrNull, Map, MapIndexed, MapNotNull, Max, MaxBy, MaxWith, Merge, Min, MinBy,
     Minus, MinWith, None, OnEach, Partition, Plus, Reduce, ReduceIndexed, Reverse, Single, SingleOrNull, Sorted, SortedBy, SortedByDescending, SortedDescending, SortedWith,
     Sum, SumBy, Take, TakeWhile, ToArray, ToMap, ToSet, Unzip, WithIndex, Zip {
 }
@@ -100,7 +102,7 @@ class SequenceImpl<T> {
 
 applyMixins(SequenceImpl, [All, Any, AsIterable, Associate, AssociateBy, Average, Chunk, Contains, Count, Distinct, DistinctBy, Drop,
     DropWhile, ElementAt, ElementAtOrElse, ElementAtOrNull, Filter, FilterIndexed, FilterNot, FilterNotNull, First, FirstOrNull, FlatMap, Flatten, Fold, FoldIndexed,
-    ForEach, ForEachIndexed, GroupBy, IndexOf, IndexOfFirst, IndexOfLast, JoinToString, Last, LastOrNull, Map, MapIndexed, MapNotNull, Max, MaxBy, MaxWith, Merge, Min, MinBy,
+    ForEach, ForEachIndexed, GroupBy, IndexOf, IndexOfFirst, IndexOfLast, IsEmpty, IsNotEmpty, JoinToString, Last, LastOrNull, Map, MapIndexed, MapNotNull, Max, MaxBy, MaxWith, Merge, Min, MinBy,
     Minus, MinWith, None, OnEach, Partition, Plus, Reduce, ReduceIndexed, Reverse, Single, SingleOrNull, Sorted, SortedBy, SortedByDescending, SortedDescending, SortedWith,
     Sum, SumBy, Take, TakeWhile, ToArray, ToMap, ToSet, Unzip, WithIndex, Zip]);
 

--- a/src/isEmpty.ts
+++ b/src/isEmpty.ts
@@ -1,0 +1,12 @@
+import Sequence from "./Sequence";
+
+export class IsEmpty {
+    /**
+     * Returns `true` the sequence is empty
+     *
+     * @returns {boolean}
+     */
+    isEmpty<T>(this: Sequence<T>) {
+        return !this.isNotEmpty();
+    }
+}

--- a/src/isNotEmpty.ts
+++ b/src/isNotEmpty.ts
@@ -1,0 +1,12 @@
+import Sequence from "./Sequence";
+
+export class IsNotEmpty {
+    /**
+     * Returns `true` the sequence is not empty
+     *
+     * @returns {boolean}
+     */
+    isNotEmpty<T>(this: Sequence<T>) {
+        return this.any(() => true);
+    }
+}

--- a/test/isEmpty.test.ts
+++ b/test/isEmpty.test.ts
@@ -1,0 +1,19 @@
+import { range, sequenceOf } from "../src/Sequence";
+
+describe("isEmpty", () => {
+    it("returns false for infinite sequences", () => {
+        expect(range(0, Infinity).isEmpty()).toBeFalsy();
+    });
+
+    it("returns true for empty sequences", () => {
+        expect(sequenceOf().isEmpty()).toBeTruthy();
+    });
+
+    it("returns true for sequences that would be empty", () => {
+        expect(sequenceOf(1, 3).filter(x => x % 2 === 0).isEmpty()).toBeTruthy();
+    });
+
+    it("returns false for sequences that would not be empty", () => {
+        expect(sequenceOf(1, 3).filter(x => x % 2 !== 0).isEmpty()).toBeFalsy();
+    });
+});

--- a/test/isNotEmpty.test.ts
+++ b/test/isNotEmpty.test.ts
@@ -1,0 +1,19 @@
+import { range, sequenceOf } from "../src/Sequence";
+
+describe("isNotEmpty", () => {
+    it("returns true for infinite sequences", () => {
+        expect(range(0, Infinity).isNotEmpty()).toBeTruthy();
+    });
+
+    it("returns false for empty sequences", () => {
+        expect(sequenceOf().isNotEmpty()).toBeFalsy();
+    });
+
+    it("returns false for sequences that would be empty", () => {
+        expect(sequenceOf(1, 3).filter(x => x % 2 === 0).isNotEmpty()).toBeFalsy();
+    });
+
+    it("returns true for sequences that would not be empty", () => {
+        expect(sequenceOf(1, 3).filter(x => x % 2 !== 0).isNotEmpty()).toBeTruthy();
+    });
+});


### PR DESCRIPTION
This PR adds two new (terminal) methods:
* `isEmpty` that checks whether the sequence contains absolutely no element
* `isNotEmpty` that checks whether the sequence contains at least one element

Both are implemented in the laziest way possible and are compatible with (potentially) infinite sequences as their source.